### PR TITLE
step slug getting matched within the object slug

### DIFF
--- a/src/merlin/wizards/session.py
+++ b/src/merlin/wizards/session.py
@@ -136,7 +136,7 @@ class SessionWizard(object):
         """
         Returns the base URL of the wizard.
         """
-        index = request.path.find(step.slug)
+        index = request.path.rfind(step.slug)
 
         return request.path[:index]
 


### PR DESCRIPTION
If the step slug is found within the object slug, the url will become clipped and a 404 will be thrown.
Using rfind to search back form the end of the url will prevent this from happening.
