### PR TITLE
Fix for issue #12

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -45,13 +45,13 @@ defaults =
     --verbosity=1
 
 [versions]
-BeautifulSoup = 3.1.0.1
+BeautifulSoup = 3.2.0
 coverage = 3.3.1
 distribute = 0.6.14
 django = 1.2.1
 docutils = 0.7
 Jinja2 = 2.5.2
-nose = 0.11.4
+nose = 1.1.2
 pbp.recipe.noserunner = 0.2.6
 Pygments = 1.3.1
 Sphinx = 1.0.3

--- a/src/merlin/wizards/session.py
+++ b/src/merlin/wizards/session.py
@@ -128,9 +128,7 @@ class SessionWizard(object):
         """
         Returns the base URL of the wizard.
         """
-        index = request.path.find(step.slug)
-
-        return request.path[:index]
+        return request.path[:request.path.rindex(step.slug)]
 
     def process_GET(self, request, step):
         """


### PR DESCRIPTION
Fix's the issue where the base url also contains the slug name (e.g. /registration/business/buy-referral/referral) and properly returns the base url.
