### PR TITLE
Handle redirection inside the cancel method in order to allow developers...

### DIFF
--- a/src/merlin/wizards/session.py
+++ b/src/merlin/wizards/session.py
@@ -70,10 +70,7 @@ class SessionWizard(object):
 
         if not step:
             if slug == 'cancel':
-                self.cancel(request)
-                redirect = request.REQUEST.get('rd', '/')
-
-                return HttpResponseRedirect(redirect)
+                return self.cancel(request)
 
             raise MissingStepException("Step for slug %s not found." % slug)
 
@@ -383,12 +380,16 @@ class SessionWizard(object):
         """
         Hook used to cancel a wizard. This will be called when slug is passed
         that matches "cancel". By default the method will clear the session
-        data.
+        data, then redirect to the url specified in the `rd` GET parameter.
+        
+        Override this method to cause the redirection to head somewhere else.
 
         :param request:
             A ``HttpRequest`` object for this request.
         """
         self.clear(request)
+        redirect = request.REQUEST.get('rd', '/')
+        return HttpResponseRedirect(redirect)
 
     def process_show_form(self, request, step, form):
         """


### PR DESCRIPTION
... to override the redirection target.

Currently the only way to override redirection target in the 'cancel' scenario is to suffix your cancel link with `?rd=/some-path/` which is fairly subpar.

This patch changes nothing of the default behaviour, except that it now allows subclassed wizards to redirect to a location by specifying it inside the wizard python code.
