### PR TITLE
Missing Symbol when running under Django 1.5a1

### DIFF
--- a/src/merlin/wizards/session.py
+++ b/src/merlin/wizards/session.py
@@ -1,3 +1,5 @@
+from urlparse import urljoin
+
 from functools import wraps
 
 from django.http import *

--- a/src/merlin/wizards/session.py
+++ b/src/merlin/wizards/session.py
@@ -166,7 +166,13 @@ class SessionWizard(object):
 
         self.set_cleaned_data(request, step, form.cleaned_data)
         self.process_step(request, step, form)
-        next_step = self.get_after(request, step)
+
+        slug = request.POST.get('slug', None)
+
+        if slug:
+            next_step = self.get_step(request, slug)
+        else:
+            next_step = self.get_after(request, step)
 
         if next_step:
             url_base = self._get_URL_base(request, step)


### PR DESCRIPTION
Looks like the Django guys moved the import for urlparse.urljoin() from django/http/**init**.py to django/http/request.py.  They might move it back but if this function is needed in session.py it's probably best to just import it directly.  Here's a proposed fix for your review.

Thanks for this project, I just started playing with it and it looks a _LOT_ better than the Form Wizard stuff that ships with Django.  If I find any other issues with using this and Django 1.5 I'll let you know.
